### PR TITLE
Refactor: Transition to Ruff for linting and formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ help: ## Show this help message
 
 install: ## Install dependencies with uv
 	uv sync --all-extras
-	uv run python -c "import nltk; nltk.download('punkt', quiet=True); nltk.download('stopwords', quiet=True)" || true
 
 test: test-unit ## Run all tests
 
@@ -20,12 +19,14 @@ test-sample: ## Run sample duplicate detection analysis
 	@echo "Running sample analysis..."
 	@uv run python -c "import sys, os; sys.path.insert(0, 'scripts'); from duplicate_logic_detector import DuplicateLogicDetector; detector = DuplicateLogicDetector('.'); matches = detector.analyze_pr_changes(['test_samples/duplicate_code.py'], 'base', 'head'); print(f'Found {len(matches)} potential duplicates'); [print(f'  - {match.new_function.name} vs {match.existing_function.name} (similarity: {match.similarity_score:.2%})') for match in matches]"
 
-lint: ## Run linting with flake8
-	uv run flake8 scripts/ tests/ --max-line-length=88
+lint: ## Run linting with ruff
+	uv run ruff check scripts/ tests/
 
-format: ## Format code with black and isort
-	uv run black scripts/ tests/
-	uv run isort scripts/ tests/
+format: ## Format code with ruff
+	uv run ruff format scripts/ tests/
+
+lint-fix: ## Run linting with ruff and fix issues automatically
+	uv run ruff check --fix scripts/ tests/
 
 type-check: ## Run type checking with mypy
 	uv run mypy scripts/
@@ -33,10 +34,10 @@ type-check: ## Run type checking with mypy
 clean: ## Clean up temporary files
 	find . -type f -name "*.pyc" -delete
 	find . -type d -name "__pycache__" -delete
-	rm -rf htmlcov/ .coverage .pytest_cache/ .mypy_cache/
+	rm -rf htmlcov/ .coverage .pytest_cache/ .mypy_cache/ .ruff_cache/
 	rm -f duplicate-logic-report.json duplicate-logic-report.md
 
-all: install lint type-check test ## Install, lint, type-check, and test
+all: install format lint type-check test ## Install, format, lint, type-check, and test
 
 dev-setup: install ## Set up development environment
 	@echo "Development environment ready!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,7 @@ test = [
     "pytest-xdist>=3.0.0",
 ]
 dev = [
-    "black>=23.0.0",
-    "isort>=5.12.0",
-    "flake8>=6.0.0",
+    "ruff>=0.6.0",
     "mypy>=1.0.0",
     "pre-commit>=3.0.0",
 ]
@@ -98,29 +96,87 @@ exclude_lines = [
     "if __name__ == .__main__.:",
 ]
 
-[tool.black]
+[tool.ruff]
+# Same as Black.
 line-length = 88
-target-version = ['py310', 'py311', 'py312']
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-  # directories
-  \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | build
-  | dist
-)/
-'''
+indent-width = 4
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 88
-known_first_party = ["scripts"]
+# Assume Python 3.10+
+target-version = "py310"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = [
+    "E4",   # Import errors
+    "E7",   # Statement errors  
+    "E9",   # Runtime errors
+    "F",    # Pyflakes
+    "W",    # pycodestyle warnings
+    "I",    # isort
+    "N",    # pep8-naming
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "A",    # flake8-builtins
+    "C4",   # flake8-comprehensions
+    "T20",  # flake8-print
+    "SIM",  # flake8-simplify
+]
+ignore = [
+    "E501",  # Line too long (handled by formatter)
+    "T201",  # print statements (allowed for this project)
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[tool.ruff.lint.isort]
+known-first-party = ["scripts"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/scripts/duplicate_logic_detector.py
+++ b/scripts/duplicate_logic_detector.py
@@ -22,116 +22,112 @@ import hashlib
 import json
 import os
 import re
-import sys
-from collections import defaultdict
-from dataclasses import dataclass, asdict
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
 import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
 
 try:
-    import git
-    from github import Github
-    import numpy as np
+    from rich.console import Console
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.table import Table
     from sklearn.feature_extraction.text import TfidfVectorizer
     from sklearn.metrics.pairwise import cosine_similarity
-    import nltk
-    from nltk.tokenize import word_tokenize
-    from nltk.corpus import stopwords
-    from rich.console import Console
-    from rich.table import Table
-    from rich.progress import Progress, SpinnerColumn, TextColumn
 except ImportError as e:
     print(f"Error importing required dependencies: {e}")
     print("Please install required packages:")
-    print("pip install GitPython PyGithub scikit-learn nltk rich")
+    print("pip install scikit-learn rich")
     sys.exit(1)
 
 
 @dataclass
 class CodeFunction:
     """Represents a function extracted from code."""
+
     name: str
     file_path: str
     line_start: int
     line_end: int
     signature: str
-    docstring: Optional[str]
+    docstring: str | None
     body_hash: str
-    imports: List[str]  # Changed from Set to List for JSON serialization
-    calls: List[str]    # Changed from Set to List for JSON serialization
+    imports: list[str]  # Changed from Set to List for JSON serialization
+    calls: list[str]  # Changed from Set to List for JSON serialization
     complexity_score: float
     ast_structure: str
-    
+
 
 @dataclass
 class DuplicateMatch:
     """Represents a potential duplicate logic match."""
+
     new_function: CodeFunction
     existing_function: CodeFunction
     similarity_score: float
     match_type: str
     confidence: str
-    reasons: List[str]
+    reasons: list[str]
     suggestion: str
 
 
 class ASTAnalyzer:
     """Analyzes Python AST for structural patterns and similarity."""
-    
+
     def __init__(self):
         self.console = Console()
-    
-    def extract_functions_from_file(self, file_path: str) -> List[CodeFunction]:
+
+    def extract_functions_from_file(self, file_path: str) -> list[CodeFunction]:
         """Extract all functions from a Python file."""
         try:
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(file_path, encoding="utf-8") as f:
                 content = f.read()
-            
+
             tree = ast.parse(content, filename=file_path)
             functions = []
-            
+
             for node in ast.walk(tree):
                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     func = self._extract_function_info(node, content, file_path)
                     if func:
                         functions.append(func)
-            
+
             return functions
         except Exception as e:
             self.console.print(f"[red]Error parsing {file_path}: {e}[/red]")
             return []
-    
-    def _extract_function_info(self, node: Union[ast.FunctionDef, ast.AsyncFunctionDef], 
-                             content: str, file_path: str) -> Optional[CodeFunction]:
+
+    def _extract_function_info(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef, content: str, file_path: str
+    ) -> CodeFunction | None:
         """Extract detailed information about a function."""
         try:
             # Get function signature
             signature = self._get_function_signature(node)
-            
+
             # Get docstring
             docstring = ast.get_docstring(node)
-            
+
             # Get function body
-            lines = content.split('\n')
+            lines = content.split("\n")
             line_start = node.lineno
             line_end = node.end_lineno or line_start
-            
+
             # Calculate body hash (excluding comments and docstrings)
-            body_lines = lines[line_start-1:line_end]
-            normalized_body = self._normalize_code('\n'.join(body_lines))
+            body_lines = lines[line_start - 1 : line_end]
+            normalized_body = self._normalize_code("\n".join(body_lines))
             body_hash = hashlib.md5(normalized_body.encode()).hexdigest()
-            
+
             # Extract imports and function calls
             imports = self._extract_imports(node)
             calls = self._extract_function_calls(node)
-            
+
             # Calculate complexity score
             complexity = self._calculate_complexity(node)
-            
+
             # Get AST structure fingerprint
             ast_structure = self._get_ast_structure(node)
-            
+
             return CodeFunction(
                 name=node.name,
                 file_path=file_path,
@@ -143,57 +139,59 @@ class ASTAnalyzer:
                 imports=imports,
                 calls=calls,
                 complexity_score=complexity,
-                ast_structure=ast_structure
+                ast_structure=ast_structure,
             )
         except Exception as e:
             self.console.print(f"[red]Error extracting function {node.name}: {e}[/red]")
             return None
-    
-    def _get_function_signature(self, node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> str:
+
+    def _get_function_signature(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> str:
         """Extract normalized function signature."""
         args = []
-        
+
         # Regular arguments
         for arg in node.args.args:
             arg_str = arg.arg
             if arg.annotation:
                 arg_str += f": {ast.unparse(arg.annotation)}"
             args.append(arg_str)
-        
+
         # Handle *args and **kwargs
         if node.args.vararg:
             vararg = f"*{node.args.vararg.arg}"
             if node.args.vararg.annotation:
                 vararg += f": {ast.unparse(node.args.vararg.annotation)}"
             args.append(vararg)
-        
+
         if node.args.kwarg:
             kwarg = f"**{node.args.kwarg.arg}"
             if node.args.kwarg.annotation:
                 kwarg += f": {ast.unparse(node.args.kwarg.annotation)}"
             args.append(kwarg)
-        
+
         # Return type
         returns = ""
         if node.returns:
             returns = f" -> {ast.unparse(node.returns)}"
-        
+
         prefix = "async " if isinstance(node, ast.AsyncFunctionDef) else ""
         return f"{prefix}def {node.name}({', '.join(args)}){returns}"
-    
+
     def _normalize_code(self, code: str) -> str:
         """Normalize code by removing comments, extra whitespace, etc."""
         lines = []
-        for line in code.split('\n'):
+        for line in code.split("\n"):
             # Remove comments
-            line = re.sub(r'#.*$', '', line)
+            line = re.sub(r"#.*$", "", line)
             # Normalize whitespace
-            line = re.sub(r'\s+', ' ', line.strip())
+            line = re.sub(r"\s+", " ", line.strip())
             if line:
                 lines.append(line)
-        return '\n'.join(lines)
-    
-    def _extract_imports(self, node: ast.AST) -> Set[str]:
+        return "\n".join(lines)
+
+    def _extract_imports(self, node: ast.AST) -> set[str]:
         """Extract all imports used within a function."""
         imports = []
         for child in ast.walk(node):
@@ -205,8 +203,8 @@ class ASTAnalyzer:
                 if attr_str not in imports:
                     imports.append(attr_str)
         return imports
-    
-    def _extract_function_calls(self, node: ast.AST) -> Set[str]:
+
+    def _extract_function_calls(self, node: ast.AST) -> set[str]:
         """Extract all function calls within a function."""
         calls = []
         for child in ast.walk(node):
@@ -219,59 +217,54 @@ class ASTAnalyzer:
                     if func_str not in calls:
                         calls.append(func_str)
         return calls
-    
+
     def _calculate_complexity(self, node: ast.AST) -> float:
         """Calculate cyclomatic complexity of a function."""
         complexity = 1  # Base complexity
-        
+
         for child in ast.walk(node):
-            if isinstance(child, (ast.If, ast.While, ast.For, ast.AsyncFor)):
+            if isinstance(
+                child,
+                (
+                    ast.If,
+                    ast.While,
+                    ast.For,
+                    ast.AsyncFor,
+                    ast.ExceptHandler,
+                    ast.And,
+                    ast.Or,
+                ),
+            ):
                 complexity += 1
-            elif isinstance(child, ast.ExceptHandler):
-                complexity += 1
-            elif isinstance(child, (ast.And, ast.Or)):
-                complexity += 1
-        
+
         return float(complexity)
-    
+
     def _get_ast_structure(self, node: ast.AST) -> str:
         """Get a structural fingerprint of the AST."""
         structure = []
         for child in ast.walk(node):
             structure.append(type(child).__name__)
-        return ','.join(sorted(set(structure)))
+        return ",".join(sorted(set(structure)))
 
 
 class SemanticAnalyzer:
     """Analyzes semantic similarity between code functions."""
-    
+
     def __init__(self):
         self.console = Console()
         self.vectorizer = TfidfVectorizer(
-            stop_words='english',
-            ngram_range=(1, 3),
-            max_features=1000
+            stop_words="english", ngram_range=(1, 3), max_features=1000
         )
-        self._ensure_nltk_data()
-    
-    def _ensure_nltk_data(self):
-        """Ensure required NLTK data is downloaded."""
-        try:
-            nltk.data.find('tokenizers/punkt')
-            nltk.data.find('corpora/stopwords')
-        except LookupError:
-            nltk.download('punkt', quiet=True)
-            nltk.download('stopwords', quiet=True)
-    
+
     def calculate_similarity(self, func1: CodeFunction, func2: CodeFunction) -> float:
         """Calculate semantic similarity between two functions."""
         # Combine various text features
         text1 = self._extract_text_features(func1)
         text2 = self._extract_text_features(func2)
-        
+
         if not text1 or not text2:
             return 0.0
-        
+
         try:
             # Use TF-IDF vectorization
             vectors = self.vectorizer.fit_transform([text1, text2])
@@ -279,164 +272,206 @@ class SemanticAnalyzer:
             return float(similarity)
         except Exception:
             return 0.0
-    
+
     def _extract_text_features(self, func: CodeFunction) -> str:
         """Extract textual features from a function for similarity analysis."""
         features = []
-        
+
         # Function name (split camelCase/snake_case and extract keywords)
-        name_tokens = re.sub(r'([a-z])([A-Z])', r'\1 \2', func.name).lower()
-        name_tokens = re.sub(r'[_-]', ' ', name_tokens)
+        name_tokens = re.sub(r"([a-z])([A-Z])", r"\1 \2", func.name).lower()
+        name_tokens = re.sub(r"[_-]", " ", name_tokens)
         features.append(name_tokens)
-        
+
         # Extract semantic keywords from function name
         semantic_keywords = []
         name_lower = func.name.lower()
-        if 'validate' in name_lower or 'check' in name_lower or 'verify' in name_lower:
-            semantic_keywords.append('validation')
-        if 'email' in name_lower or 'mail' in name_lower:
-            semantic_keywords.append('email')
-        if 'user' in name_lower or 'customer' in name_lower:
-            semantic_keywords.append('user')
-        if 'data' in name_lower or 'info' in name_lower:
-            semantic_keywords.append('data')
-        if 'process' in name_lower or 'transform' in name_lower or 'convert' in name_lower:
-            semantic_keywords.append('processing')
-        if 'calculate' in name_lower or 'compute' in name_lower or 'score' in name_lower:
-            semantic_keywords.append('calculation')
-        
+        if "validate" in name_lower or "check" in name_lower or "verify" in name_lower:
+            semantic_keywords.append("validation")
+        if "email" in name_lower or "mail" in name_lower:
+            semantic_keywords.append("email")
+        if "user" in name_lower or "customer" in name_lower:
+            semantic_keywords.append("user")
+        if "data" in name_lower or "info" in name_lower:
+            semantic_keywords.append("data")
+        if (
+            "process" in name_lower
+            or "transform" in name_lower
+            or "convert" in name_lower
+        ):
+            semantic_keywords.append("processing")
+        if (
+            "calculate" in name_lower
+            or "compute" in name_lower
+            or "score" in name_lower
+        ):
+            semantic_keywords.append("calculation")
+
         features.extend(semantic_keywords)
-        
+
         # Docstring (extract key terms)
         if func.docstring:
             doc_lower = func.docstring.lower()
             features.append(doc_lower)
             # Extract key terms from docstring
-            if 'email' in doc_lower:
-                features.append('email')
-            if 'validate' in doc_lower or 'check' in doc_lower:
-                features.append('validation')
-            if 'user' in doc_lower:
-                features.append('user')
-            if 'data' in doc_lower:
-                features.append('data')
-        
+            if "email" in doc_lower:
+                features.append("email")
+            if "validate" in doc_lower or "check" in doc_lower:
+                features.append("validation")
+            if "user" in doc_lower:
+                features.append("user")
+            if "data" in doc_lower:
+                features.append("data")
+
         # Function calls (meaningful names only)
-        meaningful_calls = {call for call in func.calls 
-                          if len(call) > 2 and not call.startswith('_')}
+        meaningful_calls = {
+            call for call in func.calls if len(call) > 2 and not call.startswith("_")
+        }
         features.extend(meaningful_calls)
-        
+
         # Add regex pattern detection for common patterns
-        if 're.match' in func.calls or 'match' in func.calls:
-            features.append('regex pattern matching')
-        if 'get' in ' '.join(func.calls):
-            features.append('data access')
-        
+        if "re.match" in func.calls or "match" in func.calls:
+            features.append("regex pattern matching")
+        if "get" in " ".join(func.calls):
+            features.append("data access")
+
         # Imports (domain-specific terms)
-        domain_imports = {imp for imp in func.imports 
-                         if any(keyword in imp.lower() for keyword in 
-                               ['user', 'auth', 'data', 'api', 'db', 'service', 'util', 'email', 'mail'])}
+        domain_imports = {
+            imp
+            for imp in func.imports
+            if any(
+                keyword in imp.lower()
+                for keyword in [
+                    "user",
+                    "auth",
+                    "data",
+                    "api",
+                    "db",
+                    "service",
+                    "util",
+                    "email",
+                    "mail",
+                ]
+            )
+        }
         features.extend(domain_imports)
-        
-        return ' '.join(features)
+
+        return " ".join(features)
 
 
 class DuplicateLogicDetector:
     """Main class for detecting duplicate logic in code changes."""
-    
+
     def __init__(self, repository_path: str):
         self.repo_path = Path(repository_path)
         self.console = Console()
         self.ast_analyzer = ASTAnalyzer()
         self.semantic_analyzer = SemanticAnalyzer()
-        self.existing_functions: List[CodeFunction] = []
-        
+        self.existing_functions: list[CodeFunction] = []
+
         # Thresholds for different types of matches
         self.EXACT_MATCH_THRESHOLD = 0.90
         self.HIGH_SIMILARITY_THRESHOLD = 0.70
         self.MODERATE_SIMILARITY_THRESHOLD = 0.50
-        
-    def analyze_pr_changes(self, changed_files: List[str], base_sha: str, head_sha: str) -> List[DuplicateMatch]:
+
+    def analyze_pr_changes(
+        self, changed_files: list[str], base_sha: str, head_sha: str
+    ) -> list[DuplicateMatch]:
         """Analyze changes in a pull request for duplicate logic."""
         matches = []
-        
+
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
-            console=self.console
+            console=self.console,
         ) as progress:
             # Load existing codebase functions
             task1 = progress.add_task("Indexing existing codebase...", total=None)
             self._index_existing_functions()
             progress.update(task1, completed=True)
-            
+
             # Analyze changed files
-            task2 = progress.add_task("Analyzing changed files...", total=len(changed_files))
-            
+            task2 = progress.add_task(
+                "Analyzing changed files...", total=len(changed_files)
+            )
+
             for file_path in changed_files:
-                if not file_path.endswith('.py') or not Path(file_path).exists():
+                if not file_path.endswith(".py") or not Path(file_path).exists():
                     progress.advance(task2)
                     continue
-                
+
                 # Get new/modified functions in this file
-                new_functions = self._get_changed_functions(file_path, base_sha, head_sha)
-                
+                new_functions = self._get_changed_functions(
+                    file_path, base_sha, head_sha
+                )
+
                 # Check each new function against existing ones
                 for new_func in new_functions:
                     function_matches = self._find_similar_functions(new_func)
                     matches.extend(function_matches)
-                
+
                 progress.advance(task2)
-        
+
         # Sort matches by similarity score (highest first)
         matches.sort(key=lambda m: m.similarity_score, reverse=True)
-        
+
         return matches
-    
+
     def _index_existing_functions(self):
         """Index all functions in the existing codebase."""
         self.existing_functions = []
-        
+
         # Find all Python files in src/ and tests/
         python_files = []
-        for pattern in ['src/**/*.py', 'tests/**/*.py']:
+        for pattern in ["src/**/*.py", "tests/**/*.py"]:
             python_files.extend(self.repo_path.glob(pattern))
-        
+
         for file_path in python_files:
             if file_path.is_file():
-                functions = self.ast_analyzer.extract_functions_from_file(str(file_path))
+                functions = self.ast_analyzer.extract_functions_from_file(
+                    str(file_path)
+                )
                 self.existing_functions.extend(functions)
-        
-        self.console.print(f"[green]Indexed {len(self.existing_functions)} functions from codebase[/green]")
-    
-    def _get_changed_functions(self, file_path: str, base_sha: str, head_sha: str) -> List[CodeFunction]:
+
+        self.console.print(
+            f"[green]Indexed {len(self.existing_functions)} functions from codebase[/green]"
+        )
+
+    def _get_changed_functions(
+        self, file_path: str, base_sha: str, head_sha: str
+    ) -> list[CodeFunction]:
         """Get functions that were added or significantly modified in a file."""
         try:
             # Get current functions
             current_functions = self.ast_analyzer.extract_functions_from_file(file_path)
-            
+
             # Try to get the base version of the file
             try:
                 result = subprocess.run(
-                    ['git', 'show', f'{base_sha}:{file_path}'],
-                    capture_output=True, text=True, cwd=self.repo_path
+                    ["git", "show", f"{base_sha}:{file_path}"],
+                    capture_output=True,
+                    text=True,
+                    cwd=self.repo_path,
                 )
                 if result.returncode == 0:
                     # Write base version to temp file and analyze
                     temp_file = Path(f"/tmp/base_{Path(file_path).name}")
                     temp_file.write_text(result.stdout)
-                    base_functions = self.ast_analyzer.extract_functions_from_file(str(temp_file))
+                    base_functions = self.ast_analyzer.extract_functions_from_file(
+                        str(temp_file)
+                    )
                     temp_file.unlink()
-                    
+
                     # Find new or significantly changed functions
                     base_func_hashes = {f.name: f.body_hash for f in base_functions}
                     changed_functions = []
-                    
+
                     for func in current_functions:
-                        if (func.name not in base_func_hashes or 
-                            base_func_hashes[func.name] != func.body_hash):
+                        if (
+                            func.name not in base_func_hashes
+                            or base_func_hashes[func.name] != func.body_hash
+                        ):
                             changed_functions.append(func)
-                    
+
                     return changed_functions
                 else:
                     # File is new, all functions are new
@@ -444,28 +479,36 @@ class DuplicateLogicDetector:
             except Exception:
                 # If we can't get base version, treat all functions as new
                 return current_functions
-                
+
         except Exception as e:
-            self.console.print(f"[red]Error analyzing changes in {file_path}: {e}[/red]")
+            self.console.print(
+                f"[red]Error analyzing changes in {file_path}: {e}[/red]"
+            )
             return []
-    
-    def _find_similar_functions(self, new_func: CodeFunction) -> List[DuplicateMatch]:
+
+    def _find_similar_functions(self, new_func: CodeFunction) -> list[DuplicateMatch]:
         """Find existing functions similar to the new function."""
         matches = []
-        
+
         for existing_func in self.existing_functions:
             # Skip if it's the same function (same file and name)
-            if (existing_func.file_path == new_func.file_path and 
-                existing_func.name == new_func.name):
+            if (
+                existing_func.file_path == new_func.file_path
+                and existing_func.name == new_func.name
+            ):
                 continue
-            
+
             # Calculate various similarity metrics
-            similarity_score, match_type, reasons = self._calculate_similarity(new_func, existing_func)
-            
+            similarity_score, match_type, reasons = self._calculate_similarity(
+                new_func, existing_func
+            )
+
             if similarity_score >= self.MODERATE_SIMILARITY_THRESHOLD:
                 confidence = self._determine_confidence(similarity_score)
-                suggestion = self._generate_suggestion(new_func, existing_func, similarity_score)
-                
+                suggestion = self._generate_suggestion(
+                    new_func, existing_func, similarity_score
+                )
+
                 match = DuplicateMatch(
                     new_function=new_func,
                     existing_function=existing_func,
@@ -473,39 +516,45 @@ class DuplicateLogicDetector:
                     match_type=match_type,
                     confidence=confidence,
                     reasons=reasons,
-                    suggestion=suggestion
+                    suggestion=suggestion,
                 )
                 matches.append(match)
-        
+
         return matches
-    
-    def _calculate_similarity(self, func1: CodeFunction, func2: CodeFunction) -> Tuple[float, str, List[str]]:
+
+    def _calculate_similarity(
+        self, func1: CodeFunction, func2: CodeFunction
+    ) -> tuple[float, str, list[str]]:
         """Calculate comprehensive similarity between two functions."""
         scores = []
         reasons = []
-        
+
         # 1. Exact body hash match
         if func1.body_hash == func2.body_hash:
             return 1.0, "exact_duplicate", ["Identical function body"]
-        
+
         # 2. Function signature similarity
-        sig_similarity = difflib.SequenceMatcher(None, func1.signature, func2.signature).ratio()
+        sig_similarity = difflib.SequenceMatcher(
+            None, func1.signature, func2.signature
+        ).ratio()
         scores.append(sig_similarity * 0.25)
         if sig_similarity > 0.6:
             reasons.append(f"Similar function signature ({sig_similarity:.2f})")
-        
+
         # 3. Semantic similarity (enhanced)
         semantic_similarity = self.semantic_analyzer.calculate_similarity(func1, func2)
         scores.append(semantic_similarity * 0.35)
         if semantic_similarity > 0.3:
             reasons.append(f"Similar semantic content ({semantic_similarity:.2f})")
-        
+
         # 4. AST structure similarity
-        ast_similarity = self._compare_ast_structures(func1.ast_structure, func2.ast_structure)
+        ast_similarity = self._compare_ast_structures(
+            func1.ast_structure, func2.ast_structure
+        )
         scores.append(ast_similarity * 0.25)
         if ast_similarity > 0.5:
             reasons.append(f"Similar code structure ({ast_similarity:.2f})")
-        
+
         # 5. Function calls overlap
         if func1.calls and func2.calls:
             calls_set1 = set(func1.calls)
@@ -514,22 +563,28 @@ class DuplicateLogicDetector:
             scores.append(calls_overlap * 0.15)
             if calls_overlap > 0.3:
                 reasons.append(f"Similar function calls ({calls_overlap:.2f})")
-        
+
         # 6. Function name similarity (new)
-        name_similarity = difflib.SequenceMatcher(None, func1.name.lower(), func2.name.lower()).ratio()
+        name_similarity = difflib.SequenceMatcher(
+            None, func1.name.lower(), func2.name.lower()
+        ).ratio()
         if name_similarity > 0.4:
             scores.append(name_similarity * 0.1)
             reasons.append(f"Similar function names ({name_similarity:.2f})")
-        
+
         # 7. Complexity similarity bonus
         if func1.complexity_score > 1 and func2.complexity_score > 1:
-            complexity_ratio = min(func1.complexity_score, func2.complexity_score) / max(func1.complexity_score, func2.complexity_score)
+            complexity_ratio = min(
+                func1.complexity_score, func2.complexity_score
+            ) / max(func1.complexity_score, func2.complexity_score)
             if complexity_ratio > 0.8:
                 scores.append(0.05)  # Small bonus for similar complexity
-                reasons.append(f"Similar complexity ({func1.complexity_score} vs {func2.complexity_score})")
-        
+                reasons.append(
+                    f"Similar complexity ({func1.complexity_score} vs {func2.complexity_score})"
+                )
+
         overall_similarity = sum(scores)
-        
+
         # Determine match type
         if overall_similarity >= self.EXACT_MATCH_THRESHOLD:
             match_type = "near_duplicate"
@@ -537,22 +592,22 @@ class DuplicateLogicDetector:
             match_type = "high_similarity"
         else:
             match_type = "moderate_similarity"
-        
+
         return overall_similarity, match_type, reasons
-    
+
     def _compare_ast_structures(self, struct1: str, struct2: str) -> float:
         """Compare AST structure fingerprints."""
         if not struct1 or not struct2:
             return 0.0
-        
-        set1 = set(struct1.split(','))
-        set2 = set(struct2.split(','))
-        
+
+        set1 = set(struct1.split(","))
+        set2 = set(struct2.split(","))
+
         if not set1 or not set2:
             return 0.0
-        
+
         return len(set1 & set2) / len(set1 | set2)
-    
+
     def _determine_confidence(self, similarity_score: float) -> str:
         """Determine confidence level based on similarity score."""
         if similarity_score >= self.EXACT_MATCH_THRESHOLD:
@@ -563,59 +618,70 @@ class DuplicateLogicDetector:
             return "medium"
         else:
             return "low"
-    
-    def _generate_suggestion(self, new_func: CodeFunction, existing_func: CodeFunction, 
-                           similarity_score: float) -> str:
+
+    def _generate_suggestion(
+        self,
+        new_func: CodeFunction,
+        existing_func: CodeFunction,
+        similarity_score: float,
+    ) -> str:
         """Generate a suggestion for handling the duplicate logic."""
         if similarity_score >= self.EXACT_MATCH_THRESHOLD:
-            return (f"Consider reusing the existing function `{existing_func.name}` "
-                   f"from `{existing_func.file_path}` instead of implementing similar logic.")
+            return (
+                f"Consider reusing the existing function `{existing_func.name}` "
+                f"from `{existing_func.file_path}` instead of implementing similar logic."
+            )
         elif similarity_score >= self.HIGH_SIMILARITY_THRESHOLD:
-            return (f"Review the existing function `{existing_func.name}` in "
-                   f"`{existing_func.file_path}` - it may provide similar functionality "
-                   f"that could be extended or refactored for reuse.")
+            return (
+                f"Review the existing function `{existing_func.name}` in "
+                f"`{existing_func.file_path}` - it may provide similar functionality "
+                f"that could be extended or refactored for reuse."
+            )
         else:
-            return (f"Consider reviewing `{existing_func.name}` in "
-                   f"`{existing_func.file_path}` for potential code reuse opportunities.")
+            return (
+                f"Consider reviewing `{existing_func.name}` in "
+                f"`{existing_func.file_path}` for potential code reuse opportunities."
+            )
 
 
 class ReportGenerator:
     """Generates reports for duplicate logic analysis."""
-    
+
     def __init__(self):
         self.console = Console()
-    
-    def generate_github_comment(self, matches: List[DuplicateMatch]) -> str:
+
+    def generate_github_comment(self, matches: list[DuplicateMatch]) -> str:
         """Generate a GitHub PR comment with duplicate logic findings."""
         if not matches:
             return ""
-        
+
         # Filter to only high-confidence matches for PR comments
-        significant_matches = [m for m in matches 
-                             if m.confidence in ['high', 'very_high']]
-        
+        significant_matches = [
+            m for m in matches if m.confidence in ["high", "very_high"]
+        ]
+
         if not significant_matches:
             return ""
-        
+
         comment = "## 🔍 Duplicate Logic Detection\n\n"
         comment += "The following functions in your PR may recreate logic that already exists:\n\n"
-        
+
         for i, match in enumerate(significant_matches[:5], 1):  # Limit to top 5
             confidence_emoji = "🚨" if match.confidence == "very_high" else "⚠️"
-            
+
             comment += f"### {confidence_emoji} Match #{i}\n"
             comment += f"**New Function:** `{match.new_function.name}` in `{match.new_function.file_path}`\n"
             comment += f"**Similar to:** `{match.existing_function.name}` in `{match.existing_function.file_path}`\n"
             comment += f"**Similarity:** {match.similarity_score:.1%} ({match.confidence} confidence)\n"
             comment += f"**Type:** {match.match_type.replace('_', ' ').title()}\n\n"
-            
+
             comment += "**Reasons:**\n"
             for reason in match.reasons:
                 comment += f"- {reason}\n"
-            
+
             comment += f"\n**Suggestion:** {match.suggestion}\n\n"
             comment += "---\n\n"
-        
+
         comment += "<details>\n<summary>ℹ️ About this check</summary>\n\n"
         comment += "This automated analysis compares new functions against the existing codebase using:\n"
         comment += "- Abstract Syntax Tree (AST) structure analysis\n"
@@ -624,124 +690,142 @@ class ReportGenerator:
         comment += "- Code pattern recognition\n\n"
         comment += "Please review these matches to avoid code duplication and improve maintainability.\n"
         comment += "</details>"
-        
+
         return comment
-    
-    def generate_json_report(self, matches: List[DuplicateMatch]) -> Dict[str, Any]:
+
+    def generate_json_report(self, matches: list[DuplicateMatch]) -> dict[str, Any]:
         """Generate a JSON report of all findings."""
         return {
             "summary": {
                 "total_matches": len(matches),
-                "high_confidence": len([m for m in matches if m.confidence == "very_high"]),
-                "medium_confidence": len([m for m in matches if m.confidence == "high"]),
-                "low_confidence": len([m for m in matches if m.confidence == "medium"])
+                "high_confidence": len(
+                    [m for m in matches if m.confidence == "very_high"]
+                ),
+                "medium_confidence": len(
+                    [m for m in matches if m.confidence == "high"]
+                ),
+                "low_confidence": len([m for m in matches if m.confidence == "medium"]),
             },
-            "matches": [asdict(match) for match in matches]
+            "matches": [asdict(match) for match in matches],
         }
-    
-    def print_console_report(self, matches: List[DuplicateMatch]):
+
+    def print_console_report(self, matches: list[DuplicateMatch]):
         """Print a formatted console report."""
         if not matches:
             self.console.print("[green]✅ No duplicate logic detected![/green]")
             return
-        
+
         table = Table(title="Duplicate Logic Detection Results")
         table.add_column("New Function", style="cyan")
         table.add_column("Existing Function", style="magenta")
         table.add_column("Similarity", style="yellow")
         table.add_column("Confidence", style="green")
-        
+
         for match in matches[:10]:  # Show top 10
             confidence_color = {
                 "very_high": "red",
-                "high": "yellow", 
+                "high": "yellow",
                 "medium": "blue",
-                "low": "dim"
+                "low": "dim",
             }.get(match.confidence, "white")
-            
+
             table.add_row(
                 f"{match.new_function.name}\n{match.new_function.file_path}",
                 f"{match.existing_function.name}\n{match.existing_function.file_path}",
                 f"{match.similarity_score:.1%}",
-                f"[{confidence_color}]{match.confidence}[/{confidence_color}]"
+                f"[{confidence_color}]{match.confidence}[/{confidence_color}]",
             )
-        
+
         self.console.print(table)
 
 
 def main():
     """Main entry point for the duplicate logic detector."""
-    parser = argparse.ArgumentParser(description="Detect duplicate logic in pull requests")
+    parser = argparse.ArgumentParser(
+        description="Detect duplicate logic in pull requests"
+    )
     parser.add_argument("--pr-number", type=int, help="Pull request number")
     parser.add_argument("--repository", help="Repository name (owner/repo)")
     parser.add_argument("--base-sha", help="Base commit SHA")
     parser.add_argument("--head-sha", help="Head commit SHA")
     parser.add_argument("--changed-files", help="JSON list of changed files")
-    parser.add_argument("--output-format", choices=["console", "github-actions", "json"], 
-                       default="console", help="Output format")
+    parser.add_argument(
+        "--output-format",
+        choices=["console", "github-actions", "json"],
+        default="console",
+        help="Output format",
+    )
     parser.add_argument("--repository-path", default=".", help="Path to repository")
-    
+
     args = parser.parse_args()
-    
+
     console = Console()
-    
+
     try:
         # Parse changed files
         if args.changed_files:
-            changed_files = [f.strip() for f in args.changed_files.strip().split('\n') if f.strip()]
+            changed_files = [
+                f.strip() for f in args.changed_files.strip().split("\n") if f.strip()
+            ]
         else:
             console.print("[red]No changed files provided[/red]")
             return 1
-        
+
         if not changed_files:
             console.print("[green]No Python files changed[/green]")
             return 0
-        
+
         # Initialize detector
         detector = DuplicateLogicDetector(args.repository_path)
-        
+
         # Analyze changes
-        matches = detector.analyze_pr_changes(changed_files, args.base_sha, args.head_sha)
-        
+        matches = detector.analyze_pr_changes(
+            changed_files, args.base_sha, args.head_sha
+        )
+
         # Generate reports
         report_gen = ReportGenerator()
-        
+
         if args.output_format == "console":
             report_gen.print_console_report(matches)
         elif args.output_format == "github-actions":
             # Generate GitHub Actions outputs
-            significant_matches = [m for m in matches if m.confidence in ['high', 'very_high']]
-            
+            significant_matches = [
+                m for m in matches if m.confidence in ["high", "very_high"]
+            ]
+
             if significant_matches:
                 # Use environment files instead of deprecated set-output
-                with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-                    f.write(f"duplicates_found=true\n")
+                with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                    f.write("duplicates_found=true\n")
                     f.write(f"match_count={len(significant_matches)}\n")
-                
+
                 # Generate markdown report
                 comment = report_gen.generate_github_comment(matches)
                 with open("duplicate-logic-report.md", "w") as f:
                     f.write(comment)
-                
-                console.print(f"[yellow]Found {len(significant_matches)} potential duplicates[/yellow]")
+
+                console.print(
+                    f"[yellow]Found {len(significant_matches)} potential duplicates[/yellow]"
+                )
             else:
                 # Use environment files instead of deprecated set-output
-                with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-                    f.write(f"duplicates_found=false\n")
-                    f.write(f"match_count=0\n")
+                with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                    f.write("duplicates_found=false\n")
+                    f.write("match_count=0\n")
                 console.print("[green]No significant duplicates found[/green]")
-            
+
             # Always generate JSON report
             json_report = report_gen.generate_json_report(matches)
             with open("duplicate-logic-report.json", "w") as f:
                 json.dump(json_report, f, indent=2)
-        
+
         elif args.output_format == "json":
             json_report = report_gen.generate_json_report(matches)
             print(json.dumps(json_report, indent=2))
-        
+
         return 0
-        
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         return 1

--- a/tests/test_duplicate_detector.py
+++ b/tests/test_duplicate_detector.py
@@ -3,28 +3,32 @@
 Test suite for duplicate logic detection functionality.
 """
 
-import pytest
-import tempfile
 import os
-from pathlib import Path
 import sys
-import json
-from unittest.mock import Mock, patch, MagicMock
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
 
 # Add the scripts directory to the path so we can import the detector
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 try:
     from duplicate_logic_detector import (
-        CodeFunction, DuplicateMatch, DuplicateLogicDetector
+        CodeFunction,
+        DuplicateLogicDetector,
+        DuplicateMatch,
     )
 except ImportError:
-    pytest.skip("duplicate_logic_detector module not available", allow_module_level=True)
+    pytest.skip(
+        "duplicate_logic_detector module not available", allow_module_level=True
+    )
 
 
 class TestCodeFunction:
     """Test the CodeFunction dataclass."""
-    
+
     def test_code_function_creation(self):
         """Test creating a CodeFunction instance."""
         func = CodeFunction(
@@ -38,9 +42,9 @@ class TestCodeFunction:
             imports={"os", "sys"},
             calls={"print", "len"},
             complexity_score=2.5,
-            ast_structure="FunctionDef"
+            ast_structure="FunctionDef",
         )
-        
+
         assert func.name == "test_function"
         assert func.file_path == "test.py"
         assert func.line_start == 1
@@ -50,20 +54,36 @@ class TestCodeFunction:
 
 class TestDuplicateMatch:
     """Test the DuplicateMatch dataclass."""
-    
+
     def test_duplicate_match_creation(self):
         """Test creating a DuplicateMatch instance."""
         func1 = CodeFunction(
-            name="func1", file_path="file1.py", line_start=1, line_end=5,
-            signature="def func1():", docstring=None, body_hash="hash1",
-            imports=set(), calls=set(), complexity_score=1.0, ast_structure="FunctionDef"
+            name="func1",
+            file_path="file1.py",
+            line_start=1,
+            line_end=5,
+            signature="def func1():",
+            docstring=None,
+            body_hash="hash1",
+            imports=set(),
+            calls=set(),
+            complexity_score=1.0,
+            ast_structure="FunctionDef",
         )
         func2 = CodeFunction(
-            name="func2", file_path="file2.py", line_start=10, line_end=15,
-            signature="def func2():", docstring=None, body_hash="hash2",
-            imports=set(), calls=set(), complexity_score=1.0, ast_structure="FunctionDef"
+            name="func2",
+            file_path="file2.py",
+            line_start=10,
+            line_end=15,
+            signature="def func2():",
+            docstring=None,
+            body_hash="hash2",
+            imports=set(),
+            calls=set(),
+            complexity_score=1.0,
+            ast_structure="FunctionDef",
         )
-        
+
         match = DuplicateMatch(
             new_function=func1,
             existing_function=func2,
@@ -71,9 +91,9 @@ class TestDuplicateMatch:
             match_type="semantic",
             confidence="high",
             reasons=["High semantic similarity", "Similar function signatures"],
-            suggestion="Consider extracting common logic into a shared function"
+            suggestion="Consider extracting common logic into a shared function",
         )
-        
+
         assert match.similarity_score == 0.85
         assert match.confidence == "high"
         assert len(match.reasons) == 2
@@ -81,13 +101,13 @@ class TestDuplicateMatch:
 
 class TestDuplicateLogicDetector:
     """Test the main duplicate logic detector class."""
-    
+
     @pytest.fixture
     def temp_repo(self):
         """Create a temporary repository for testing."""
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_path = Path(temp_dir)
-            
+
             # Create a simple Python file with duplicate functions
             test_file1 = repo_path / "file1.py"
             test_file1.write_text("""
@@ -106,7 +126,7 @@ def process_data(data):
             result.append(item)
     return result
 """)
-            
+
             test_file2 = repo_path / "file2.py"
             test_file2.write_text("""
 def compute_sum(products):
@@ -124,27 +144,25 @@ def filter_active_items(items):
             filtered.append(item)
     return filtered
 """)
-            
+
             yield repo_path
-    
+
     @pytest.fixture
     def detector(self, temp_repo):
         """Create a detector instance with test configuration."""
         # Mock the necessary components
-        with patch('duplicate_logic_detector.git.Repo'):
-            detector = DuplicateLogicDetector(
-                repository_path=str(temp_repo)
-            )
+        with patch("duplicate_logic_detector.git.Repo"):
+            detector = DuplicateLogicDetector(repository_path=str(temp_repo))
             return detector
-    
+
     def test_detector_initialization(self, detector):
         """Test detector initialization."""
         assert detector is not None
-        assert hasattr(detector, 'repo_path')
-        assert hasattr(detector, 'ast_analyzer')
-        assert hasattr(detector, 'semantic_analyzer')
-    
-    @patch('duplicate_logic_detector.nltk')
+        assert hasattr(detector, "repo_path")
+        assert hasattr(detector, "ast_analyzer")
+        assert hasattr(detector, "semantic_analyzer")
+
+    @patch("duplicate_logic_detector.nltk")
     def test_extract_functions_from_file(self, mock_nltk, detector, temp_repo):
         """Test function extraction from a Python file."""
         test_file = temp_repo / "test_extract.py"
@@ -157,17 +175,17 @@ class TestClass:
     def method(self, y):
         return y + 1
 """)
-        
+
         # Mock NLTK dependencies
         mock_nltk.download.return_value = True
-        
+
         functions = detector.ast_analyzer.extract_functions_from_file(str(test_file))
-        
+
         # Should extract both the function and the method
         assert len(functions) >= 1
         function_names = [f.name for f in functions]
         assert "simple_function" in function_names
-    
+
     def test_calculate_similarity(self, detector):
         """Test similarity calculation between two functions."""
         func1 = CodeFunction(
@@ -181,9 +199,9 @@ class TestClass:
             imports=set(),
             calls={"get"},
             complexity_score=2.0,
-            ast_structure="FunctionDef[body=[For[target=Name[id=item]]]]"
+            ast_structure="FunctionDef[body=[For[target=Name[id=item]]]]",
         )
-        
+
         func2 = CodeFunction(
             name="compute_sum",
             file_path="file2.py",
@@ -195,18 +213,18 @@ class TestClass:
             imports=set(),
             calls={"get"},
             complexity_score=2.0,
-            ast_structure="FunctionDef[body=[For[target=Name[id=product]]]]"
+            ast_structure="FunctionDef[body=[For[target=Name[id=product]]]]",
         )
-        
+
         similarity = detector.semantic_analyzer.calculate_similarity(func1, func2)
-        
+
         # Should detect some similarity between these similar functions
         assert similarity > 0.0
         assert isinstance(similarity, float)
         assert 0 <= similarity <= 1
-    
-    @patch('duplicate_logic_detector.TfidfVectorizer')
-    @patch('duplicate_logic_detector.cosine_similarity')
+
+    @patch("duplicate_logic_detector.TfidfVectorizer")
+    @patch("duplicate_logic_detector.cosine_similarity")
     def test_semantic_similarity(self, mock_cosine, mock_tfidf, detector):
         """Test semantic similarity calculation."""
         # Mock TF-IDF and cosine similarity
@@ -214,23 +232,39 @@ class TestClass:
         mock_tfidf.return_value = mock_vectorizer
         mock_vectorizer.fit_transform.return_value = [[0.5, 0.3], [0.4, 0.6]]
         mock_cosine.return_value = [[1.0, 0.8], [0.8, 1.0]]
-        
+
         func1 = CodeFunction(
-            name="func1", file_path="file1.py", line_start=1, line_end=5,
-            signature="def func1():", docstring="Process data", body_hash="hash1",
-            imports=set(), calls=set(), complexity_score=1.0, ast_structure="FunctionDef"
+            name="func1",
+            file_path="file1.py",
+            line_start=1,
+            line_end=5,
+            signature="def func1():",
+            docstring="Process data",
+            body_hash="hash1",
+            imports=set(),
+            calls=set(),
+            complexity_score=1.0,
+            ast_structure="FunctionDef",
         )
         func2 = CodeFunction(
-            name="func2", file_path="file2.py", line_start=1, line_end=5,
-            signature="def func2():", docstring="Handle information", body_hash="hash2",
-            imports=set(), calls=set(), complexity_score=1.0, ast_structure="FunctionDef"
+            name="func2",
+            file_path="file2.py",
+            line_start=1,
+            line_end=5,
+            signature="def func2():",
+            docstring="Handle information",
+            body_hash="hash2",
+            imports=set(),
+            calls=set(),
+            complexity_score=1.0,
+            ast_structure="FunctionDef",
         )
-        
+
         similarity = detector.semantic_analyzer.calculate_similarity(func1, func2)
-        
+
         assert isinstance(similarity, float)
         assert 0 <= similarity <= 1
-    
+
     def test_determine_confidence_level(self, detector):
         """Test confidence level determination."""
         # Test the confidence mapping based on similarity scores
@@ -238,42 +272,62 @@ class TestClass:
         assert detector._determine_confidence(0.85) == "high"
         assert detector._determine_confidence(0.65) == "medium"
         assert detector._determine_confidence(0.45) == "low"
-    
+
     def test_generate_suggestions(self, detector):
         """Test suggestion generation for duplicate matches."""
         func1 = CodeFunction(
-            name="calculate_total", file_path="file1.py", line_start=1, line_end=5,
-            signature="def calculate_total(items):", docstring=None, body_hash="hash1",
-            imports=set(), calls=set(), complexity_score=1.0, ast_structure="FunctionDef"
+            name="calculate_total",
+            file_path="file1.py",
+            line_start=1,
+            line_end=5,
+            signature="def calculate_total(items):",
+            docstring=None,
+            body_hash="hash1",
+            imports=set(),
+            calls=set(),
+            complexity_score=1.0,
+            ast_structure="FunctionDef",
         )
         func2 = CodeFunction(
-            name="compute_sum", file_path="file2.py", line_start=1, line_end=5,
-            signature="def compute_sum(products):", docstring=None, body_hash="hash2",
-            imports=set(), calls=set(), complexity_score=1.0, ast_structure="FunctionDef"
+            name="compute_sum",
+            file_path="file2.py",
+            line_start=1,
+            line_end=5,
+            signature="def compute_sum(products):",
+            docstring=None,
+            body_hash="hash2",
+            imports=set(),
+            calls=set(),
+            complexity_score=1.0,
+            ast_structure="FunctionDef",
         )
-        
+
         suggestion = detector._generate_suggestion(func1, func2, 0.85)
-        
+
         assert isinstance(suggestion, str)
         assert len(suggestion) > 0
-        assert "review" in suggestion.lower() or "consider" in suggestion.lower() or "refactor" in suggestion.lower()
+        assert (
+            "review" in suggestion.lower()
+            or "consider" in suggestion.lower()
+            or "refactor" in suggestion.lower()
+        )
 
 
 class TestIntegration:
     """Integration tests for the complete duplicate detection process."""
-    
+
     @pytest.fixture
     def sample_repo(self):
         """Create a sample repository with known duplicates."""
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_path = Path(temp_dir)
-            
+
             # File with original functions
             (repo_path / "original.py").write_text("""
 def validate_email(email):
     \"\"\"Validate email format.\"\"\"
     import re
-    pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$'
     return re.match(pattern, email) is not None
 
 def calculate_discount(price, percentage):
@@ -282,13 +336,13 @@ def calculate_discount(price, percentage):
         return 0
     return price * (percentage / 100)
 """)
-            
+
             # File with duplicate functions (slightly different names/structure)
             (repo_path / "duplicates.py").write_text("""
 def check_email_format(email_address):
     \"\"\"Check if email address is valid.\"\"\"
     import re
-    email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$'
     return re.match(email_pattern, email_address) is not None
 
 def compute_discount_amount(original_price, discount_percent):
@@ -297,32 +351,30 @@ def compute_discount_amount(original_price, discount_percent):
         return 0
     return original_price * (discount_percent / 100)
 """)
-            
+
             yield repo_path
-    
-    @patch('duplicate_logic_detector.git.Repo')
-    @patch('duplicate_logic_detector.nltk')
+
+    @patch("duplicate_logic_detector.git.Repo")
+    @patch("duplicate_logic_detector.nltk")
     def test_full_duplicate_detection(self, mock_nltk, mock_repo, sample_repo):
         """Test the complete duplicate detection process."""
         # Mock NLTK
         mock_nltk.download.return_value = True
         mock_nltk.data.find.side_effect = LookupError()  # Force download
-        
+
         # Mock git repo
         mock_repo_instance = Mock()
         mock_repo.return_value = mock_repo_instance
-        
-        detector = DuplicateLogicDetector(
-            repository_path=str(sample_repo)
-        )
-        
+
+        detector = DuplicateLogicDetector(repository_path=str(sample_repo))
+
         # Run detection on the sample files
         changed_files = ["duplicates.py"]
         matches = detector.analyze_pr_changes(changed_files, "base_sha", "head_sha")
-        
+
         # Should detect the duplicate functions (may be 0 if files not found)
         assert len(matches) >= 0
-        
+
         # Verify match properties
         for match in matches:
             assert isinstance(match, DuplicateMatch)

--- a/uv.lock
+++ b/uv.lock
@@ -10,41 +10,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "black"
-version = "25.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/43/20b5c90612d7bdb2bdbcceeb53d588acca3bb8f0e4c5d5c751a2c8fdd55a/black-25.9.0.tar.gz", hash = "sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619", size = 648393, upload-time = "2025-09-19T00:27:37.758Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/40/dbe31fc56b218a858c8fc6f5d8d3ba61c1fa7e989d43d4a4574b8b992840/black-25.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ce41ed2614b706fd55fd0b4a6909d06b5bab344ffbfadc6ef34ae50adba3d4f7", size = 1715605, upload-time = "2025-09-19T00:36:13.483Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b2/f46800621200eab6479b1f4c0e3ede5b4c06b768e79ee228bc80270bcc74/black-25.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ab0ce111ef026790e9b13bd216fa7bc48edd934ffc4cbf78808b235793cbc92", size = 1571829, upload-time = "2025-09-19T00:32:42.13Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/5c7f66bd65af5c19b4ea86062bb585adc28d51d37babf70969e804dbd5c2/black-25.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f96b6726d690c96c60ba682955199f8c39abc1ae0c3a494a9c62c0184049a713", size = 1631888, upload-time = "2025-09-19T00:30:54.212Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/64/0b9e5bfcf67db25a6eef6d9be6726499a8a72ebab3888c2de135190853d3/black-25.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:d119957b37cc641596063cd7db2656c5be3752ac17877017b2ffcdb9dfc4d2b1", size = 1327056, upload-time = "2025-09-19T00:31:08.877Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/f4/7531d4a336d2d4ac6cc101662184c8e7d068b548d35d874415ed9f4116ef/black-25.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:456386fe87bad41b806d53c062e2974615825c7a52159cde7ccaeb0695fa28fa", size = 1698727, upload-time = "2025-09-19T00:31:14.264Z" },
-    { url = "https://files.pythonhosted.org/packages/28/f9/66f26bfbbf84b949cc77a41a43e138d83b109502cd9c52dfc94070ca51f2/black-25.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a16b14a44c1af60a210d8da28e108e13e75a284bf21a9afa6b4571f96ab8bb9d", size = 1555679, upload-time = "2025-09-19T00:31:29.265Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/59/61475115906052f415f518a648a9ac679d7afbc8da1c16f8fdf68a8cebed/black-25.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaf319612536d502fdd0e88ce52d8f1352b2c0a955cc2798f79eeca9d3af0608", size = 1617453, upload-time = "2025-09-19T00:30:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/5b/20fd5c884d14550c911e4fb1b0dae00d4abb60a4f3876b449c4d3a9141d5/black-25.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:c0372a93e16b3954208417bfe448e09b0de5cc721d521866cd9e0acac3c04a1f", size = 1333655, upload-time = "2025-09-19T00:30:56.715Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/8e/319cfe6c82f7e2d5bfb4d3353c6cc85b523d677ff59edc61fdb9ee275234/black-25.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1b9dc70c21ef8b43248f1d86aedd2aaf75ae110b958a7909ad8463c4aa0880b0", size = 1742012, upload-time = "2025-09-19T00:33:08.678Z" },
-    { url = "https://files.pythonhosted.org/packages/94/cc/f562fe5d0a40cd2a4e6ae3f685e4c36e365b1f7e494af99c26ff7f28117f/black-25.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e46eecf65a095fa62e53245ae2795c90bdecabd53b50c448d0a8bcd0d2e74c4", size = 1581421, upload-time = "2025-09-19T00:35:25.937Z" },
-    { url = "https://files.pythonhosted.org/packages/84/67/6db6dff1ebc8965fd7661498aea0da5d7301074b85bba8606a28f47ede4d/black-25.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9101ee58ddc2442199a25cb648d46ba22cd580b00ca4b44234a324e3ec7a0f7e", size = 1655619, upload-time = "2025-09-19T00:30:49.241Z" },
-    { url = "https://files.pythonhosted.org/packages/10/10/3faef9aa2a730306cf469d76f7f155a8cc1f66e74781298df0ba31f8b4c8/black-25.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:77e7060a00c5ec4b3367c55f39cf9b06e68965a4f2e61cecacd6d0d9b7ec945a", size = 1342481, upload-time = "2025-09-19T00:31:29.625Z" },
-    { url = "https://files.pythonhosted.org/packages/48/99/3acfea65f5e79f45472c45f87ec13037b506522719cd9d4ac86484ff51ac/black-25.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175", size = 1742165, upload-time = "2025-09-19T00:34:10.402Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/18/799285282c8236a79f25d590f0222dbd6850e14b060dfaa3e720241fd772/black-25.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f", size = 1581259, upload-time = "2025-09-19T00:32:49.685Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ce/883ec4b6303acdeca93ee06b7622f1fa383c6b3765294824165d49b1a86b/black-25.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831", size = 1655583, upload-time = "2025-09-19T00:30:44.505Z" },
-    { url = "https://files.pythonhosted.org/packages/21/17/5c253aa80a0639ccc427a5c7144534b661505ae2b5a10b77ebe13fa25334/black-25.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357", size = 1343428, upload-time = "2025-09-19T00:32:13.839Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/46/863c90dcd3f9d41b109b7f19032ae0db021f0b2a81482ba0a1e28c84de86/black-25.9.0-py3-none-any.whl", hash = "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae", size = 203363, upload-time = "2025-09-19T00:27:35.724Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -409,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "duplicate-logic-detector-action"
-version = "1.0.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
@@ -425,11 +390,9 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "black" },
-    { name = "flake8" },
-    { name = "isort" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "ruff" },
 ]
 test = [
     { name = "pytest" },
@@ -440,10 +403,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "gitpython", specifier = "==3.1.45" },
-    { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "nltk", specifier = "==3.9.1" },
     { name = "numpy", specifier = ">=1.24.0" },
@@ -456,6 +416,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = "==14.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "scikit-learn", specifier = "==1.7.2" },
 ]
 provides-extras = ["test", "dev"]
@@ -488,20 +449,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
 ]
 
 [[package]]
@@ -556,15 +503,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/21/1e2a441f74a653a144224d7d21afe8f4169e6c7c20bb13aec3a2dc3815e0/isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450", size = 821955, upload-time = "2025-02-26T21:13:16.955Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/11/114d0a5f4dabbdcedc1125dee0888514c3c3b16d3e9facad87ed96fad97c/isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615", size = 94186, upload-time = "2025-02-26T21:13:14.911Z" },
-]
-
-[[package]]
 name = "joblib"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -583,15 +521,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -948,30 +877,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -1117,15 +1028,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.1.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/5f/e959a442435e24f6fb5a01aec6c657079ceaca1b3baf18561c3728d681da/pytokens-0.1.10.tar.gz", hash = "sha256:c9a4bfa0be1d26aebce03e6884ba454e842f186a59ea43a6d3b25af58223c044", size = 12171, upload-time = "2025-02-19T14:51:22.001Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/e5/63bed382f6a7a5ba70e7e132b8b7b8abbcf4888ffa6be4877698dcfbed7d/pytokens-0.1.10-py3-none-any.whl", hash = "sha256:db7b72284e480e69fb085d9f251f66b3d2df8b7166059261258ff35f50fb711b", size = 12046, upload-time = "2025-02-19T14:51:18.694Z" },
 ]
 
 [[package]]
@@ -1334,6 +1236,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/df/8d7d8c515d33adfc540e2edf6c6021ea1c5a58a678d8cfce9fae59aabcab/ruff-0.13.2.tar.gz", hash = "sha256:cb12fffd32fb16d32cef4ed16d8c7cdc27ed7c944eaa98d99d01ab7ab0b710ff", size = 5416417, upload-time = "2025-09-25T14:54:09.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/84/5716a7fa4758e41bf70e603e13637c42cfb9dbf7ceb07180211b9bbf75ef/ruff-0.13.2-py3-none-linux_armv6l.whl", hash = "sha256:3796345842b55f033a78285e4f1641078f902020d8450cade03aad01bffd81c3", size = 12343254, upload-time = "2025-09-25T14:53:27.784Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/77/c7042582401bb9ac8eff25360e9335e901d7a1c0749a2b28ba4ecb239991/ruff-0.13.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ff7e4dda12e683e9709ac89e2dd436abf31a4d8a8fc3d89656231ed808e231d2", size = 13040891, upload-time = "2025-09-25T14:53:31.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/15/125a7f76eb295cb34d19c6778e3a82ace33730ad4e6f28d3427e134a02e0/ruff-0.13.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c75e9d2a2fafd1fdd895d0e7e24b44355984affdde1c412a6f6d3f6e16b22d46", size = 12243588, upload-time = "2025-09-25T14:53:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/eb/0093ae04a70f81f8be7fd7ed6456e926b65d238fc122311293d033fdf91e/ruff-0.13.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cceac74e7bbc53ed7d15d1042ffe7b6577bf294611ad90393bf9b2a0f0ec7cb6", size = 12491359, upload-time = "2025-09-25T14:53:35.892Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fe/72b525948a6956f07dad4a6f122336b6a05f2e3fd27471cea612349fedb9/ruff-0.13.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6ae3f469b5465ba6d9721383ae9d49310c19b452a161b57507764d7ef15f4b07", size = 12162486, upload-time = "2025-09-25T14:53:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e3/0fac422bbbfb2ea838023e0d9fcf1f30183d83ab2482800e2cb892d02dfe/ruff-0.13.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f8f9e3cd6714358238cd6626b9d43026ed19c0c018376ac1ef3c3a04ffb42d8", size = 13871203, upload-time = "2025-09-25T14:53:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/82/b721c8e3ec5df6d83ba0e45dcf00892c4f98b325256c42c38ef136496cbf/ruff-0.13.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c6ed79584a8f6cbe2e5d7dbacf7cc1ee29cbdb5df1172e77fbdadc8bb85a1f89", size = 14929635, upload-time = "2025-09-25T14:53:43.953Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a0/ad56faf6daa507b83079a1ad7a11694b87d61e6bf01c66bd82b466f21821/ruff-0.13.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aed130b2fde049cea2019f55deb939103123cdd191105f97a0599a3e753d61b0", size = 14338783, upload-time = "2025-09-25T14:53:46.205Z" },
+    { url = "https://files.pythonhosted.org/packages/47/77/ad1d9156db8f99cd01ee7e29d74b34050e8075a8438e589121fcd25c4b08/ruff-0.13.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1887c230c2c9d65ed1b4e4cfe4d255577ea28b718ae226c348ae68df958191aa", size = 13355322, upload-time = "2025-09-25T14:53:48.164Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8b/e87cfca2be6f8b9f41f0bb12dc48c6455e2d66df46fe61bb441a226f1089/ruff-0.13.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bcb10276b69b3cfea3a102ca119ffe5c6ba3901e20e60cf9efb53fa417633c3", size = 13354427, upload-time = "2025-09-25T14:53:50.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/df/bf382f3fbead082a575edb860897287f42b1b3c694bafa16bc9904c11ed3/ruff-0.13.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:afa721017aa55a555b2ff7944816587f1cb813c2c0a882d158f59b832da1660d", size = 13537637, upload-time = "2025-09-25T14:53:52.887Z" },
+    { url = "https://files.pythonhosted.org/packages/51/70/1fb7a7c8a6fc8bd15636288a46e209e81913b87988f26e1913d0851e54f4/ruff-0.13.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1dbc875cf3720c64b3990fef8939334e74cb0ca65b8dbc61d1f439201a38101b", size = 12340025, upload-time = "2025-09-25T14:53:54.88Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/27/1e5b3f1c23ca5dd4106d9d580e5c13d9acb70288bff614b3d7b638378cc9/ruff-0.13.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b939a1b2a960e9742e9a347e5bbc9b3c3d2c716f86c6ae273d9cbd64f193f22", size = 12133449, upload-time = "2025-09-25T14:53:57.089Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/09/b92a5ccee289f11ab128df57d5911224197d8d55ef3bd2043534ff72ca54/ruff-0.13.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:50e2d52acb8de3804fc5f6e2fa3ae9bdc6812410a9e46837e673ad1f90a18736", size = 13051369, upload-time = "2025-09-25T14:53:59.124Z" },
+    { url = "https://files.pythonhosted.org/packages/89/99/26c9d1c7d8150f45e346dc045cc49f23e961efceb4a70c47dea0960dea9a/ruff-0.13.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3196bc13ab2110c176b9a4ae5ff7ab676faaa1964b330a1383ba20e1e19645f2", size = 13523644, upload-time = "2025-09-25T14:54:01.622Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/00/e7f1501e81e8ec290e79527827af1d88f541d8d26151751b46108978dade/ruff-0.13.2-py3-none-win32.whl", hash = "sha256:7c2a0b7c1e87795fec3404a485096bcd790216c7c146a922d121d8b9c8f1aaac", size = 12245990, upload-time = "2025-09-25T14:54:03.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bd/d9f33a73de84fafd0146c6fba4f497c4565fe8fa8b46874b8e438869abc2/ruff-0.13.2-py3-none-win_amd64.whl", hash = "sha256:17d95fb32218357c89355f6f6f9a804133e404fc1f65694372e02a557edf8585", size = 13324004, upload-time = "2025-09-25T14:54:06.05Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/12/28fa2f597a605884deb0f65c1b1ae05111051b2a7030f5d8a4ff7f4599ba/ruff-0.13.2-py3-none-win_arm64.whl", hash = "sha256:da711b14c530412c827219312b7d7fbb4877fb31150083add7e8c5336549cea7", size = 12484437, upload-time = "2025-09-25T14:54:08.022Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Replaced Flake8 and Black with Ruff for linting and code formatting in the Makefile.
- Updated pyproject.toml to include Ruff and removed dependencies on Black, Isort, and Flake8.
- Adjusted the Makefile to include a new lint-fix target for automatic linting corrections.
- Enhanced the duplicate logic detector script by refining data types and improving code structure.
- Updated tests to reflect changes in the data structures and ensure compatibility with the new linting tool.